### PR TITLE
feat: upgrade to WordPress 7.0.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ deploy: build
 	--require-approval never \
 	--parameters AlbCertificateArn=arn:aws:acm:us-east-1:992593896645:certificate/943928d7-bfce-469c-b1bf-11561024580e \
 	--parameters AlbIngressCidr=0.0.0.0/0 \
-	--parameters AsgAmiIdv300=ami-0f390a711d584012f \
+	--parameters AsgAmiIdv310=ami-04cc4d2c12582024a \
 	--parameters AsgDesiredCapacity=1 \
 	--parameters AsgKeyName=oe-patterns-dev-dylan-us-east-1 \
 	--parameters AsgMaxSize=2 \

--- a/cdk/wordpress/wordpress_stack.py
+++ b/cdk/wordpress/wordpress_stack.py
@@ -34,8 +34,8 @@ else:
         template_version = "CICD"
 
 # Updated each release in Phase 3 (dev AMI) and Phase 6 prereqs (prod AMI).
-AMI_ID="ami-0f390a711d584012f" # ordinary-experts-patterns-wordpress-3.0.0-20260502 (dev AMI for taskcat — restored post-3.0.0 release)
-NEXT_RELEASE_PREFIX = "v300"
+AMI_ID="ami-04cc4d2c12582024a" # ordinary-experts-patterns-wordpress-3.1.0-20260720-0905 (dev AMI, WordPress 7.0.2)
+NEXT_RELEASE_PREFIX = "v310"
 
 class WordPressStack(Stack):
 

--- a/packer/ubuntu_2204_appinstall.sh
+++ b/packer/ubuntu_2204_appinstall.sh
@@ -70,7 +70,7 @@ EOF
 a2enmod rewrite
 a2enmod ssl
 
-WORDPRESS_VERSION=6.9.4
+WORDPRESS_VERSION=7.0.2
 
 # download WordPress
 curl https://wordpress.org/wordpress-$WORDPRESS_VERSION.zip -o /root/wordpress-$WORDPRESS_VERSION.zip


### PR DESCRIPTION
What changed

Upgrades the pattern's bundled WordPress version from 6.9.4 → 7.0.2 (the latest stable release), following the standard UPGRADE.md (https://github.com/ordinaryexperts/aws-marketplace-utilities/blob/main/UPGRADE.md) workflow.

- packer/ubuntu_2204_appinstall.sh — bump WORDPRESS_VERSION to 7.0.2. No other packer changes needed: the bundled theme/plugin names the script deletes (twentytwentythree, twentytwentyfour, hello.php, akismet) were verified against the actual 7.0.2 zip and are unchanged, and PHP/MySQL minimum requirements didn't move (Ubuntu 22.04's PHP 8.1 is still supported).
- cdk/wordpress/wordpress_stack.py — bump the versioned AMI parameter suffix NEXT_RELEASE_PREFIX from v300 to v310, and update AMI_ID to the new dev AMI (ami-04cc4d2c12582024a) built from the updated packer script.
- Makefile — rename the deploy target's CloudFormation parameter from AsgAmiIdv300 to AsgAmiIdv310 to match.

No CDK library bumps needed — oe-patterns-cdk-common (4.5.1) and aws-cdk-lib (2.225.0) were already at the latest known-good versions.

Why

Routine upstream version upgrade — WordPress 7.0 ("Armstrong") adds new blocks (Gallery lightbox, Heading, Breadcrumbs, Icons), an AI integration hub, and an admin theme redesign. No breaking changes, no forced database migrations, no new default theme to account for.

Testing

- make synth / make lint — clean (lint: only pre-existing VPC subnet-ref warnings, unrelated to this change)
- Dev AMI built successfully via make ami-ec2-build
- make deploy — dev stack oe-patterns-wordpress-iris deployed cleanly, all 64 resources CREATE_COMPLETE
- make test-integration (Playwright) — install wizard → admin login → Gutenberg post → public homepage render, all passed
- Manually verified the deployed site (confirmed running WordPress 7.0.2)
- make destroy — stack torn down cleanly, no leftover resources
- make test-main (taskcat) — regression stack reached CREATE_COMPLETE in us-east-1 and auto-destroyed cleanly

Follow-ups (not in this PR)

- marketplace_config.yaml still references "6.9.4" in its descriptions and points its diagram URL at the 3.0.0 path — needs updating in Phase 6 (Marketplace submission) alongside the new pattern version.
- CHANGELOG entry and release/3.1.0 branch come next per the upgrade workflow.